### PR TITLE
include ABVDM messages as valid VDM messages

### DIFF
--- a/epd-common/src/main/java/dk/dma/epd/common/prototype/sensor/nmea/NmeaSensor.java
+++ b/epd-common/src/main/java/dk/dma/epd/common/prototype/sensor/nmea/NmeaSensor.java
@@ -250,9 +250,10 @@ public abstract class NmeaSensor extends MapHandlerChild implements Runnable {
         }
     }
 
-    protected boolean isVdm(String msg) {
-        return msg.indexOf("!AIVDM") >= 0 || msg.indexOf("!AIVDO") >= 0 || msg.indexOf("!BSVDM") >= 0;
-    }
+	protected boolean isVdm(String msg) {
+		return msg.indexOf("!AIVDM") >= 0 || msg.indexOf("!AIVDO") >= 0
+		        || msg.indexOf("!BSVDM") >= 0 || msg.indexOf("!ABVDM") >= 0;
+	}
 
     protected void handleAis(String msg) {
         AisPacket packet;


### PR DESCRIPTION
First off thanks for a great product! I'm with the Australian Maritime Safety Authority and impressed with the range of products DMA has on github. I hope to be in touch more about your other stuff soon.

Kerry Abercrombie (who I believe has been in contact) asked for some assistance with figuring out why large chunks of area had no position reports using EPD-Shore. It turns out that many messages arriving to AMSA via our base stations use AB as the talker prefix (i.e. !ABVDM) and this is not recognized by ```NmeaSensor``` as a valid VDM message and is thus ignored in terms of the display.

This PR adds ABVDM as a valid VDM  message.